### PR TITLE
Feature/update-styles-and-exit-validation-assessment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+bun.lock

--- a/src/app/(main)/faq/page.tsx
+++ b/src/app/(main)/faq/page.tsx
@@ -228,16 +228,16 @@ export default function FAQPage() {
         >
           <Card className="bg-gradient-to-r from-cyan-600 to-cyan-700 text-white">
             <CardContent className="p-8 lg:p-12">
-              <h2 className="text-3xl font-bold mb-4">Still have questions?</h2>
+              <h2 className="text-3xl font-bold mb-4">{t.faq.bannerTitle} </h2>
               <p className="text-xl mb-8 opacity-90">
-                Our support team is here to help you with any additional questions or concerns.
+                {t.faq.bannerDescription}
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
                 <Button asChild variant="secondary" size="lg">
-                  <Link href="/contact">Contact Support</Link>
+                  <Link href="/contact">{t.help.contactSupport}</Link>
                 </Button>
-                <Button asChild variant="outline" size="lg" className="text-white border-white hover:bg-white hover:text-cyan-600">
-                  <Link href="/">Start Assessment</Link>
+                <Button asChild variant="outline" size="lg" className="bg-transparent text-white border-white hover:bg-white hover:text-cyan-600">
+                  <Link href="/">{t.homepage.startAssessment}</Link>
                 </Button>
               </div>
             </CardContent>

--- a/src/app/(main)/help/page.tsx
+++ b/src/app/(main)/help/page.tsx
@@ -349,7 +349,7 @@ export default function HelpPage() {
                 <Button asChild size="lg" variant="secondary">
                   <Link href="/contact">{t.help.contactSupport}</Link>
                 </Button>
-                <Button asChild size="lg" variant="outline" className="text-white border-white hover:bg-white hover:text-cyan-600">
+                <Button asChild size="lg" variant="outline" className="text-white bg-transparent border-white hover:bg-white hover:text-cyan-600">
                   <Link href="/">{t.help.startAssessment}</Link>
                 </Button>
               </div>

--- a/src/app/(main)/medical-ai/page.tsx
+++ b/src/app/(main)/medical-ai/page.tsx
@@ -330,7 +330,7 @@ export default function VitalCheckPage() {
                 <Button asChild size="lg" variant="secondary">
                   <Link href="/symptom-checker">{t.vitalCheck.tryAIAssessment}</Link>
                 </Button>
-                <Button asChild size="lg" variant="outline" className="text-white border-white hover:bg-white hover:text-cyan-600">
+                <Button asChild size="lg" variant="outline" className="text-white bg-transparent border-white hover:bg-white hover:text-cyan-600">
                   <Link href="/questionnaires">{t.vitalCheck.viewQuestionnaires}</Link>
                 </Button>
               </div>

--- a/src/app/(main)/questionnaires/page.tsx
+++ b/src/app/(main)/questionnaires/page.tsx
@@ -253,7 +253,7 @@ export default function QuestionnairesPage() {
                 <Button asChild size="lg" variant="secondary">
                   <Link href="/symptom-checker">{t.questionnaire.startGeneralAssessment}</Link>
                 </Button>
-                <Button asChild size="lg" variant="outline" className="text-white border-white hover:bg-white hover:text-cyan-600">
+                <Button asChild size="lg" variant="outline" className="text-white border-white bg-transparent hover:bg-white hover:text-cyan-600">
                   <Link href="/">{t.questionnaire.learnMore}</Link>
                 </Button>
               </div>

--- a/src/app/(main)/symptoms/page.tsx
+++ b/src/app/(main)/symptoms/page.tsx
@@ -364,7 +364,7 @@ export default function SymptomsPage() {
                 <Button asChild size="lg" variant="secondary">
                   <Link href="/symptom-checker">{t.homepage.startAssessment}</Link>
                 </Button>
-                <Button asChild size="lg" variant="outline" className="text-white border-white hover:bg-white hover:text-cyan-600">
+                <Button asChild size="lg" variant="outline" className="text-white bg-transparent border-white hover:bg-white hover:text-cyan-600">
                   <Link href="/questionnaires">{t.navigation.questionnaires}</Link>
                 </Button>
               </div>

--- a/src/app/(main)/vital-check/page.tsx
+++ b/src/app/(main)/vital-check/page.tsx
@@ -330,7 +330,7 @@ export default function VitalCheckPage() {
                 <Button asChild size="lg" variant="secondary">
                   <Link href="/symptom-checker">{t.vitalCheck.tryAIAssessment}</Link>
                 </Button>
-                <Button asChild size="lg" variant="outline" className="text-white border-white hover:bg-white hover:text-cyan-600">
+                <Button asChild size="lg" variant="outline" className="text-white bg-transparent border-white hover:bg-white hover:text-cyan-600">
                   <Link href="/questionnaires">{t.vitalCheck.viewQuestionnaires}</Link>
                 </Button>
               </div>

--- a/src/components/homepage/modern-homepage.tsx
+++ b/src/components/homepage/modern-homepage.tsx
@@ -603,7 +603,7 @@ export function ModernHomepage() {
                           </div>
                           <Button
                             onClick={handleSearch}
-                            className="bg-cyan-600 hover:bg-cyan-700 text-white px-6 lg:px-8 py-4 h-14 rounded-xl font-semibold transition-all duration-300 min-w-[100px] lg:min-w-[120px] flex items-center justify-center"
+                            className="bg-cyan-600 hover:bg-cyan-700 text-white px-6 lg:px-8 py-0.5 h-12 rounded-xl font-semibold transition-all duration-300 min-w-[100px] lg:min-w-[120px] flex items-center justify-center"
                           >
                             <Activity className="icon-sm mr-2" />
                             <span className="hidden sm:inline">Search</span>
@@ -1578,7 +1578,7 @@ export function ModernHomepage() {
                                   className="w-full px-4 py-3 lg:py-4 rounded-lg bg-white text-gray-900 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-cyan-600 text-sm lg:text-base transition-all duration-300 border-0 min-h-12 lg:min-h-14"
                                 />
                               </div>
-                              <Button className="bg-white hover:bg-gray-100 text-cyan-600 px-6 lg:px-8 py-3 lg:py-4 rounded-lg font-semibold text-sm lg:text-base whitespace-nowrap transition-all duration-300 hover:shadow-lg border-0 flex items-center justify-center min-h-12 lg:min-h-14">
+                              <Button className="bg-transparent hover:bg-white text-white border border-white hover:text-cyan-600 px-6 lg:px-8 py-3 lg:py-4 rounded-lg font-semibold text-sm lg:text-base whitespace-nowrap transition-all duration-300 hover:shadow-lg flex items-center justify-center min-h-12 lg:min-h-14">
                                 {t.homepage.subscribe}
                               </Button>
                             </div>

--- a/src/components/symptom-checker/dynamic-questionnaire.tsx
+++ b/src/components/symptom-checker/dynamic-questionnaire.tsx
@@ -536,18 +536,21 @@ export function DynamicQuestionnaire({
 
       {/* Navigation Confirmation Dialog */}
       <Dialog open={showNavigationDialog} onOpenChange={() => {}}>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent
+          className="sm:max-w-md"
+          handleCancelExit={handleCancelExit}
+        >
           <DialogHeader>
             <DialogTitle className="flex items-center space-x-2">
               <AlertTriangle className="h-5 w-5 text-orange-500" />
               <span>{t.common.confirmExit || 'Confirm Exit'}</span>
             </DialogTitle>
           </DialogHeader>
-          
+
           <div className="py-4">
             <p className="text-gray-600">
-              {t.questionnaire.exitWarning || 
-               'Are you sure you want to leave? Your progress will be lost and you\'ll need to start over.'}
+              {t.questionnaire.exitWarning ||
+                "Are you sure you want to leave? Your progress will be lost and you'll need to start over."}
             </p>
           </div>
 
@@ -570,5 +573,5 @@ export function DynamicQuestionnaire({
         </DialogContent>
       </Dialog>
     </>
-  )
+  );
 }

--- a/src/components/symptom-checker/symptom-checker.tsx
+++ b/src/components/symptom-checker/symptom-checker.tsx
@@ -13,10 +13,11 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { LanguageSwitcher } from '@/components/ui/language-switcher'
 import { useTranslations, useLanguage } from '@/contexts/language-context'
-import { AlertTriangle, Settings } from 'lucide-react'
+import { AlertTriangle, Settings, ArrowLeft } from 'lucide-react';
 import { LoadingCard } from '@/components/ui/loading-spinner'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useScrollToTop } from '@/hooks/use-scroll-to-top'
+import { useRouter } from 'next/navigation';
 
 type AppState = 'disclaimer' | 'questionnaire' | 'loading' | 'results' | 'error' | 'config-error' | 'declined'
 
@@ -33,6 +34,7 @@ export function SymptomChecker({ initialQuery, initialTopic }: SymptomCheckerPro
   const [responses, setResponses] = useState<QuestionResponse[]>([])
   const t = useTranslations()
   const { language } = useLanguage()
+  const router = useRouter();
 
   // Scroll to top when component mounts or state changes
   useScrollToTop([state])
@@ -139,6 +141,11 @@ export function SymptomChecker({ initialQuery, initialTopic }: SymptomCheckerPro
     setResponses([])
   }
 
+  const handleBackToHome = () => {
+    router.push('/');
+  };
+
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-cyan-50 to-cyan-100 py-8 px-4">
       <div className="max-w-6xl mx-auto">
@@ -148,7 +155,15 @@ export function SymptomChecker({ initialQuery, initialTopic }: SymptomCheckerPro
           animate={{ opacity: 1, y: 0 }}
           className="text-center mb-8"
         >
-          <div className="flex justify-end mb-4">
+          <div className="flex justify-between items-center mb-4">
+            <Button
+              onClick={() => router.back()}
+              variant="outline"
+              className="flex items-center space-x-2 bg-white hover:bg-gray-50 border-gray-200 text-gray-700 hover:text-gray-900"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              <span>{t.common.back || 'Back'}</span>
+            </Button>
             <LanguageSwitcher />
           </div>
           <h1 className="text-4xl font-bold text-gray-900 mb-2">
@@ -269,6 +284,7 @@ export function SymptomChecker({ initialQuery, initialTopic }: SymptomCheckerPro
                 onEmergencyDetected={handleEmergencyDetected}
                 initialQuery={initialQuery}
                 initialTopic={initialTopic}
+                onBackToHome={handleBackToHome}
               />
             </motion.div>
           )}

--- a/src/components/ui/async-autocomplete.tsx
+++ b/src/components/ui/async-autocomplete.tsx
@@ -70,8 +70,8 @@ type StyleFn = (provided: Record<string, unknown>, state: StyleState) => Record<
 const customStyles: Record<string, StyleFn | (() => Record<string, unknown>)> = {
   control: (provided, state) => ({
     ...provided,
-    minHeight: "2.75rem",
-    height: "2.75rem",
+    minHeight: "3rem",
+    height: "3rem",
     borderColor: state.isFocused ? "#0891b2" : "#d1d5db",
     borderRadius: "0.5rem",
     boxShadow: state.isFocused ? "0 0 0 1px #0891b2" : "none",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer transition duration-500 ease-in-out",
   {
     variants: {
       variant: {

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -50,9 +50,11 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  handleCancelExit,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
-  showCloseButton?: boolean
+  showCloseButton?: boolean;
+  handleCancelExit?: () => void;
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
@@ -60,7 +62,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
           className
         )}
         {...props}
@@ -69,7 +71,8 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 cursor-pointer"
+            onClick={handleCancelExit}
           >
             <XIcon />
             <span className="sr-only">Close</span>
@@ -77,7 +80,7 @@ function DialogContent({
         )}
       </DialogPrimitive.Content>
     </DialogPortal>
-  )
+  );
 }
 
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {

--- a/src/lib/translations/en.ts
+++ b/src/lib/translations/en.ts
@@ -1102,7 +1102,9 @@ export const en: Translations = {
         question: "How do I delete my account?",
         answer: "You can delete your account by going to your profile settings and selecting 'Delete Account'. This will permanently remove all your data from our systems."
       }
-    }
+    },
+    bannerTitle: "Still have questions?",
+    bannerDescription: "Our support team is here to help you with any additional questions or concerns."
   },
 
   // Medical AI / VitalCheck page

--- a/src/lib/translations/es.ts
+++ b/src/lib/translations/es.ts
@@ -1102,7 +1102,9 @@ export const es: Translations = {
         question: "¿Cómo elimino mi cuenta?",
         answer: "Puedes eliminar tu cuenta yendo a la configuración de tu perfil y seleccionando 'Eliminar Cuenta'. Esto eliminará permanentemente todos tus datos de nuestros sistemas."
       }
-    }
+    },
+    bannerTitle: "¿Aún tienes preguntas?",
+    bannerDescription: "Nuestro equipo de soporte está aquí para ayudarle con cualquier pregunta o inquietud adicional."
   },
 
   // Medical AI / VitalCheck page

--- a/src/lib/translations/types.ts
+++ b/src/lib/translations/types.ts
@@ -905,7 +905,9 @@ export interface FAQTranslations {
       question: string
       answer: string
     }
-  }
+  },
+  bannerTitle: string
+  bannerDescription: string
 }
 
 // Help & FAQ


### PR DESCRIPTION
- Add missing translation to FAQ banner
- Update styles to CTA banner (These had a default white color and text making the text not visible until the user hovered.)
- X - the icon now allows you to close the `dialog component` - same functionality as CTA - cancel
- Add a CTA so that users can return to the previous page if they wish, if they do not want to complete the evaluation or if they want to exit. (Currently it has router.back() functionality to take advantage of the exit confirmation functionality - dialog.)
- Allow users to be redirected to the home page if they confirm they want to leave from the `Symptom Checker page`(I noticed that it did not redirect them to the home page and reloaded the page for the evaluation.).
- Update the style of the autocomplete component to maintain height consistency with the search component's CTA (keep it at the same height size)